### PR TITLE
fix: bitbucket Uninitiated

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ydtb/plugintoolsserver",
-  "version": "0.0.15",
+  "version": "0.0.17",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ydtb/plugintoolsserver",
-      "version": "0.0.15",
+      "version": "0.0.17",
       "license": "GPLv2 or later",
       "dependencies": {
         "@headlessui/react": "^1.7.15",

--- a/src/Commands/PTSCommands.php
+++ b/src/Commands/PTSCommands.php
@@ -17,24 +17,32 @@ class PTSCommands extends \WP_CLI_Command
 
     public function fetchAll()
     {
-        $this->bitbucketManager->cloneOrFetchRepositories();
+        if ($this->bitbucketManager){
+            $this->bitbucketManager->cloneOrFetchRepositories();
+        }
     }
 
     public function getOptions()
     {
+        if ($this->bitbucketManager){
         echo "Bitbucket_User". $this->bitbucketManager->getUser() ."\n";
         echo "Bitbucket_Workspace". $this->bitbucketManager->getWorkspace() ."\n";
         //echo "Bitbucket_AppPass: ". $this->bitbucketManager->getPassword() . "\n";
+        }
     }
 
     public function removeRepos(){
+        if ($this->bitbucketManager){
         \WP_CLI::confirm( "Are you sure you want to remove the repos?" );
         RimRaf::rrmdir($this->bitbucketManager->getTargetDir());
+        }
     }
 
     public function generateComposer(){
+        if ($this->bitbucketManager){
         $packages = $this->bitbucketManager->cloneOrFetchRepositories();
         $this->bitbucketManager->generateComposerPackages($packages);
+        }
     }
 
     public function makeKey( ){

--- a/src/Providers/Rest/Routes/PluginUpdateAPI.php
+++ b/src/Providers/Rest/Routes/PluginUpdateAPI.php
@@ -275,6 +275,10 @@ class PluginUpdateAPI implements Provider
         
         $bitbucket = new BitbucketManager(true);
 
+        if (!$this->bitbucketManager){
+            throw new \Exception('Bitbucket Settings not configured.');
+        }
+
         if (!file_exists($data['destination_path'])) {
             throw new \Exception('File does not exist.');
         }

--- a/src/Services/BitbucketManager.php
+++ b/src/Services/BitbucketManager.php
@@ -19,6 +19,10 @@ class BitbucketManager
     {
         $settings = get_option(YDTB_PTOOLS_OPTIONS_SLUG);
 
+        if (!$settings){
+            return false;
+        }
+
         $this->username = $settings['bitbucket_username'];
         $this->password = Crypto::Decrypt($settings['bitbucket_password']);
         $this->workspace = $settings['bitbucket_workspace']; // workspace slug from bitbucket

--- a/src/Services/PluginDownloadJob.php
+++ b/src/Services/PluginDownloadJob.php
@@ -24,6 +24,10 @@ class PluginDownloadJob extends \WP_Async_Request {
             $name= $_POST['plugin_name'];
             $version= $_POST['plugin_version'];
 
+            if (!$this->bitbucketManager){
+                throw new \Exception('Bitbucket Settings not configured.');
+            }
+
             $this->bitbucketManager->handlePluginUpdate($url, $slug, $name, $version);
         }
 }


### PR DESCRIPTION
If bitbucket doesn't have values yet then it generates errors, This fix allows bitbucket credentials to not be set, but will throw errors if you still try to run bitbucket actions without the credentials. 